### PR TITLE
[BE] 티켓팅 스케줄러 리팩토링

### DIFF
--- a/backend/ticket-server/.env.example
+++ b/backend/ticket-server/.env.example
@@ -7,10 +7,9 @@ REDIS_TICKET_PASSWORD=
 PERFORMANCE_API_URL=http://localhost:3002
 
 # Ticketing Cycle
-# Setup 간격 (Cron format, 매 5분되기 1분 전. 4분, 9분, 14분 19분, ...)
-# 매 5분마다 티켓팅이 진행되기 위해 1분전에 setup 과정을 진행.
+# Setup 단계 (Cron format, 매 5분 주기 1분 전: 4분, 9분, 14분, ...)
 SETUP_INTERVAL="0 4/5 * * * *"
-# Setup 이 끝나고 티켓팅 시작 딜레이 (ms, 디폴트 1분.)
-TICKETING_OPEN_DELAY=60000
-# 티켓팅이 진행되는 시간 (ms, 디폴트 3분.)
-TICKETING_DURATION=180000
+# Open 단계 (Cron format, 매 5분 주기 정각: 5분, 10분, 15분, ...)
+TICKETING_OPEN_INTERVAL="0 5/5 * * * *"
+# Close 단계 (Cron format, 매 5분 주기 3분 후: 8분, 13분, 18분, ...)
+TICKETING_CLOSE_INTERVAL="0 8/5 * * * *"


### PR DESCRIPTION
# 티켓팅 스케줄러 리팩토링

## 개요
불안정한 `setTimeout` 연쇄 실행 방식을 제거하고, **독립 CronJob**과 **상태 머신(State Machine)** 기반으로 구조 변경.

## 핵심 변경: CycleStatus 도입
각 단계의 실행 순서를 엄격히 제어하기 위해 상태 머신 적용.

### 상태 전이 규칙
`CycleStatus`에 따라 다음 단계 실행 여부를 결정.

- **SETUP** (매시 4분, 9분...):
  - 조건: 현재 상태가 `CLOSE` 또는 `ERROR` 일 때만 실행
  - 성공 시: `SETUP` 상태로 전환
- **OPEN** (매시 5분, 10분...):
  - 조건: 현재 상태가 `SETUP` 일 때만 실행
  - 성공 시: `OPEN` 상태로 전환
- **CLOSE** (매시 8분, 13분...):
  - 조건: 현재 상태가 `OPEN` 일 때만 실행
  - 성공 시: `CLOSE` 상태로 전환

### 예외 처리
- **ERROR 상태**: 각 단계 실행 중 오류 발생 시 즉시 `ERROR` 상태로 전환.
- **Skip 로직**: 이전 상태 조건이 맞지 않으면 해당 스케줄은 **실행되지 않고 건너뜀**.
  - *예: Setup 실패 시 → Open 실행 Skip → Close 실행 Skip → 다음 Setup 주기에 복구.*

## 기타 변경 사항
- **환경 변수**: `DELAY`(ms) 방식 제거 → Cron 표현식(`OPEN_INTERVAL`, `CLOSE_INTERVAL`) 도입.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 티켓팅 사이클 중 에러 발생 시 복구 메커니즘 개선
  * 잘못된 상태에서의 작업 실행 방지

* **개선 사항**
  * 티켓팅 시스템의 상태 관리 로직 재구성으로 안정성 향상
  * 예약 작업의 명시적 상태 전환(준비 → 오픈 → 종료) 구현

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->