### PR TITLE
[BE] 예약 성공 응답에 가상 유저 사이즈 포함

### DIFF
--- a/backend/ticket-server/src/reservation/dto/create-reservation-response.dto.ts
+++ b/backend/ticket-server/src/reservation/dto/create-reservation-response.dto.ts
@@ -23,4 +23,10 @@ export class CreateReservationResponseDto {
     type: [Seat],
   })
   seats: Seat[];
+
+  @ApiProperty({
+    description: '설정된 가상 유저 규모 (Queue 설정값)',
+    example: 50000,
+  })
+  virtual_user_size: number;
 }

--- a/backend/ticket-server/src/reservation/reservation.service.spec.ts
+++ b/backend/ticket-server/src/reservation/reservation.service.spec.ts
@@ -22,6 +22,7 @@ describe('ReservationService', () => {
             atomicReservation: jest.fn(),
             publishToQueue: jest.fn(),
             del: jest.fn(),
+            hgetQueue: jest.fn(),
           },
         },
       ],
@@ -155,11 +156,13 @@ describe('ReservationService', () => {
       redisService.sismember.mockResolvedValue(true);
       redisService.atomicReservation.mockResolvedValue([1, 5]);
       redisService.publishToQueue.mockResolvedValue(1);
+      redisService.hgetQueue.mockResolvedValue('50000');
 
       const result = await service.reserve(dto, userId);
 
       expect(result.rank).toBe(5);
       expect(result.seats).toEqual(dto.seats);
+      expect(result.virtual_user_size).toBe(50000);
       expect(redisService.atomicReservation).toHaveBeenCalledWith(
         ['reservation:session:1:block:10:row:0:col:0'],
         userId,

--- a/backend/ticket-server/src/reservation/reservation.service.ts
+++ b/backend/ticket-server/src/reservation/reservation.service.ts
@@ -44,7 +44,17 @@ export class ReservationService {
     );
     await this.publishReservationDoneEvent(userId);
 
-    return { rank, seats };
+    const virtual_user_size = await this.getVirtualSize();
+
+    return { rank, seats, virtual_user_size };
+  }
+
+  private async getVirtualSize(): Promise<number> {
+    const sizeStr = await this.redisService.hgetQueue(
+      REDIS_KEYS.CONFIG_QUEUE,
+      'virtual.target_total',
+    );
+    return sizeStr ? parseInt(sizeStr, 10) : 0;
   }
 
   private async validateTicketingOpen() {


### PR DESCRIPTION
- CreateReservationResponseDto: virtual_user_size 필드 추가
- ReservationService: Queue Redis에서 가상 유저 설정값 조회 로직 추가
- 테스트 코드: hgetQueue 모킹 및 응답 검증 로직 반영

---
# 변경후 Response
```json
{
  rank : 123,
  seats : [...],
  virtual_user_size : 50000
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* 예약 응답에 가상 사용자 크기 정보가 추가되었습니다. 예약 결과에서 이제 구성된 가상 사용자 크기 값을 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->